### PR TITLE
fix multiple declaration error

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,9 @@ You need libowfat (http://www.fefe.de/libowfat/).
 
 Steps to go:
 
-```bash
-cvs -d :pserver:cvs@cvs.fefe.de:/cvs -z9 co libowfat
-cd libowfat
-make
-cd ..
-cvs -d:pserver:anoncvs@cvs.erdgeist.org:/home/cvsroot co opentracker
-cd opentracker
-make
-./opentracker
-```
+clone the repo.
+use "make" command.
+start opentracker by "./opentracker -p PORT"
 
 This tracker is open in a sense that everyone announcing a torrent is welcome to do so and will be informed about anyone else announcing the same torrent. Unless
 `-DWANT_IP_FROM_QUERY_STRING` is enabled (which is meant for debugging purposes only), only source IPs are accepted. The tracker implements a minimal set of

--- a/base64.h
+++ b/base64.h
@@ -73,7 +73,7 @@ static const unsigned char unb64[]={
 // Converts binary data of length=len to base64 characters.
 // Length of the resultant string is stored in flen
 // (you must pass pointer flen).
-char* base64( const void* binaryData, int len, int *flen )
+static char* base64_enc( const void* binaryData, int len, int *flen )
 {
   const unsigned char* bin = (const unsigned char*) binaryData ;
   char* res ;
@@ -123,7 +123,7 @@ char* base64( const void* binaryData, int len, int *flen )
   return res ;
 }
 
-unsigned char* unbase64( const char* ascii, int len, int *flen )
+static unsigned char* base64_dec( const char* ascii, int len, int *flen )
 {
   const unsigned char *safeAsciiPtr = (const unsigned char*)ascii ;
   unsigned char *bin ;

--- a/ot_http.c
+++ b/ot_http.c
@@ -517,7 +517,7 @@ static ssize_t http_handle_announce( const int64 sock, struct ot_workstruct *ws,
 
         write_ptr[len-SUFFIXLEN] = '\0'; // strip .i2p ending
 
-        unsigned char * bdata = unbase64((char*)write_ptr, len-SUFFIXLEN, &blen);
+        unsigned char * bdata = base64_dec((char*)write_ptr, len-SUFFIXLEN, &blen);
         if( !bdata ) HTTPERROR_400_PARAM;
 
         sha256_init( &bctx );


### PR DESCRIPTION
turned the base64.h functions into static functions to not get repeated declaration error.